### PR TITLE
fix: ignore issue references inside HTML comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const {hasOwnProperty} = Object.prototype;
 const FENCE_BLOCK_REGEXP = /^(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))/gm;
 const CODE_BLOCK_REGEXP = /(`(?!\\))((?:.(?!\1(?!\\)))*.?)\1/g;
 const HTML_CODE_BLOCK_REGEXP = /(<code)+?((?!(<code|<\/code>)+?)[\S\s])*(<\/code>)+?/gim;
+const HTML_COMMENT_REGEXP = /<!--[\s\S]*?-->/g;
 const LEADING_TRAILING_SLASH_REGEXP = /^\/?([^/]+(?:\/[^/]+)*)\/?$/;
 const TRAILING_SLASH_REGEXP = /\/?$/;
 
@@ -76,13 +77,15 @@ function parse(text, regexp, mentionRegexp, {actions, issuePrefixes, hosts}) {
     refs: [],
     mentions: [],
   };
-  let noCodeBlock = inverse(inverse(text.replace(FENCE_BLOCK_REGEXP, '')).replace(CODE_BLOCK_REGEXP, ''));
+  let filteredText = inverse(inverse(text.replace(FENCE_BLOCK_REGEXP, '')).replace(CODE_BLOCK_REGEXP, ''));
 
-  while (regexp.test(noCodeBlock)) {
-    noCodeBlock = noCodeBlock.replace(HTML_CODE_BLOCK_REGEXP, '');
+  while (regexp.test(filteredText)) {
+    filteredText = filteredText.replace(HTML_CODE_BLOCK_REGEXP, '');
   }
 
-  while ((parsed = regexp.exec(noCodeBlock)) !== null) {
+  filteredText = filteredText.replace(HTML_COMMENT_REGEXP, ' ');
+
+  while ((parsed = regexp.exec(filteredText)) !== null) {
     let [raw, action, slug, prefix, issue, mentions] = parsed;
     prefix =
       prefix && issuePrefixes.some(issuePrefix => issuePrefix.toUpperCase() === prefix.toUpperCase())

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -298,6 +298,57 @@ Fix #2
   ]);
 });
 
+test('Exclude HTML comments', t => {
+  t.deepEqual(m('github')('Fix #1 <!-- Fix #2 --> Fix #3').actions.close, [
+    {issue: '1', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #1'},
+    {issue: '3', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #3'},
+  ]);
+
+  t.deepEqual(m('github')('Fix #1 <!-- Fixes #2 --> #3').actions.close, [
+    {issue: '1', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #1'},
+  ]);
+
+  t.deepEqual(m('github')('Fix #1 <!-- Fixes #2 --> #3').refs, [{issue: '3', slug: undefined, prefix: '#', raw: '#3'}]);
+
+  t.deepEqual(
+    m('github')(`Fix #1 <!--
+Fix #2
+Closes #3
+--> Fix #4`).actions.close,
+    [
+      {issue: '1', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #1'},
+      {issue: '4', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #4'},
+    ]
+  );
+
+  t.deepEqual(m('github')('<!-- Fix #1 -->').actions.close, []);
+
+  t.deepEqual(m('github')('<!--Fix #1-->').actions.close, []);
+
+  t.deepEqual(m('github')('Fix #1 <!-- Fix #2 --> Fix #3 <!-- Fix #4 --> Fix #5').actions.close, [
+    {issue: '1', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #1'},
+    {issue: '3', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #3'},
+    {issue: '5', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #5'},
+  ]);
+
+  t.deepEqual(m('github')('Fix #1 <!-- Fix #2 --> Fix #3 <!-- Fix #4 --> #5 <!-- Fix #6 --> #7').actions.close, [
+    {issue: '1', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #1'},
+    {issue: '3', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #3'},
+  ]);
+
+  t.deepEqual(m('github')('Fix #1 <!-- Fix #2 --> Fix #3 <!-- Fix #4 --> #5 <!-- Fix #6 --> #7').refs, [
+    {issue: '5', slug: undefined, prefix: '#', raw: '#5'},
+    {issue: '7', slug: undefined, prefix: '#', raw: '#7'},
+  ]);
+
+  t.deepEqual(m('github')('Fix #1<!-- Fix #2 -->Fix #3').actions.close, [
+    {issue: '1', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #1'},
+    {issue: '3', action: 'Fix', slug: undefined, prefix: '#', raw: 'Fix #3'},
+  ]);
+
+  t.deepEqual(m('github')('<!-- @user --> @other').mentions, [{raw: '@other', prefix: '@', user: 'other'}]);
+});
+
 test('Empty options', t => {
   t.deepEqual(m({actions: {close: []}, issuePrefixes: [], mentionsPrefixes: []})('Fix #1, @user'), {
     actions: {duplicate: []},


### PR DESCRIPTION
## Summary

Fixes semantic-release/github#143
Closes https://github.com/semantic-release/issue-parser/issues/149

  - Fix issue references being detected inside HTML comments (`<!-- -->`)
  - HTML comments are now filtered out before parsing, similar to code blocks

## Solution

  Added `HTML_COMMENT_REGEXP` to strip HTML comments from text before parsing, consistent with existing handling for:
  - Fenced code blocks (` ``` `)
  - Inline code (`` ` ``)
  - `<code>` tags

  Comments are replaced with a space (not removed entirely) to preserve word boundaries between adjacent text.

## Changes

  - `index.js`: Added `HTML_COMMENT_REGEXP` and filtering step
  - `index.js`: Renamed `noCodeBlock` → `filteredText` for clarity
  - `test/index.test.js`: Added tests for HTML comment exclusion